### PR TITLE
script to remove extra omission rows working

### DIFF
--- a/scripts/deleteExtraFoodOmissionRows.js
+++ b/scripts/deleteExtraFoodOmissionRows.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+require('node-env-file')( __dirname + '/../.env' );
+
+const Postgres = require('../dal/postgres')
+
+async function execute() {
+    const idsToDelete = [ ]
+    await Postgres.initialize()
+
+    const foodOmissionRows = await Postgres.query( `SELECT * FROM memberfoodomission`, [ ], { rowsOnly: true } )
+
+    const rowsByMemberId = foodOmissionRows.reduce( ( memo, row ) => {
+        memo[ row.memberid ] ? idsToDelete.push( row.id ) : memo[ row.memberid ] = [ ]        
+        memo[ row.memberid ].push( row )
+        return memo
+    }, { } )
+
+    console.log( 'Members with multiple rows:\n' )
+
+    Object.entries( rowsByMemberId ).forEach( ( [ key, val ] ) => {
+        if( val.length > 1 ) {
+            console.log( `Member Id: ${key}` )
+            console.log( val )
+        }
+    } )
+
+    return Postgres.query( `DELETE FROM memberfoodomission WHERE id = ANY($1)`, [ idsToDelete ] )
+}
+
+execute()
+.catch( e => { console.log( e.stack || e ); process.exit(1) } )
+.then( () => process.exit(0) )


### PR DESCRIPTION
-script goes through `memberfoodomission` rows and deletes all but the first row for each member ID. I kept the first because this is what would be displaying in admin.

-added logs to summarize all the members who have extra rows before all the extras are deleted.